### PR TITLE
remove self import from the Data.Comparison module

### DIFF
--- a/src/Data/Comparison.purs
+++ b/src/Data/Comparison.purs
@@ -2,7 +2,6 @@ module Data.Comparison where
 
 import Prelude
 
-import Data.Comparison (Comparison(..))
 import Data.Function (on)
 import Data.Functor.Contravariant (class Contravariant)
 import Data.Newtype (class Newtype)


### PR DESCRIPTION
Removes a self import from the Data.Comparison module so that things don't break once the next release of the compiler comes out