### PR TITLE
Refactor functors and related packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Bugfixes:
 Other improvements:
   - Migrated CI to GitHub Actions and updated installation instructions to use Spago (#27)
   - Added a CHANGELOG.md file and pull request template (#28, #29)
+  - This package now depends on the `purescript-const` package, and contains an instance previously in that package (#30)
 
 ## [v4.0.1](https://github.com/purescript/purescript-contravariant/releases/tag/v4.0.1) - 2019-04-27
 

--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,7 @@
     "package.json"
   ],
   "dependencies": {
+    "purescript-const": "master",
     "purescript-either": "master",
     "purescript-newtype": "master",
     "purescript-prelude": "master",

--- a/src/Data/Functor/Contravariant.purs
+++ b/src/Data/Functor/Contravariant.purs
@@ -2,6 +2,8 @@ module Data.Functor.Contravariant where
 
 import Prelude
 
+import Data.Const (Const(..))
+
 -- | A `Contravariant` functor can be seen as a way of changing the input type
 -- | of a consumer of input, in contrast to the standard covariant `Functor`
 -- | that can be seen as a way of changing the output type of a producer of
@@ -28,3 +30,6 @@ coerce a = absurd <$> (absurd >$< a)
 -- | As all `Contravariant` functors are also trivially `Invariant`, this function can be used as the `imap` implementation for any types that have an existing `Contravariant` instance.
 imapC :: forall f a b. Contravariant f => (a -> b) -> (b -> a) -> f a -> f b
 imapC _ f = cmap f
+
+instance contravariantConst :: Contravariant (Const a) where
+  cmap _ (Const x) = Const x


### PR DESCRIPTION
This is part of a set of commits that rearrange the dependencies between
multiple packages. The immediate motivation is to allow certain newtypes
to be reused between `profunctor` and `bifunctors`, but this particular
approach goes a little beyond that in two ways: first, it attempts to
move data types (`either`, `tuple`) toward the bottom of the dependency
stack; and second, it tries to ensure no package comes between
`functors` and the packages most closely related to it, in order to open
the possibility of merging those packages together (which may be
desirable if at some point in the future additional newtypes are added
which reveal new and exciting constraints on the module dependency
graph).

**Description of the change**

See discussion in purescript/purescript-profunctor#23.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
